### PR TITLE
Wikipedia extension v3

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -36,6 +36,12 @@
         "url": "https://raw.githubusercontent.com/BauwenDR/osta-wikipedia-extension/v1.0.1/wikipedia-extension.jspy",
         "configurationUrl": "https://raw.githubusercontent.com/BauwenDR/osta-wikipedia-extension/v1.0.1/variables.json",
         "fileHash": "9106ce610233b6840d774cd596e0dbb1"
+      },
+      {
+        "version": 3,
+        "url": "https://raw.githubusercontent.com/BauwenDR/osta-wikipedia-extension/v1.1.0/wikipedia-extension.jspy",
+        "configurationUrl": "https://raw.githubusercontent.com/BauwenDR/osta-wikipedia-extension/v1.1.0/variables.json",
+        "fileHash": "571a9610218a3ab021bf3350bee6b60f"
       }
     ]
   },


### PR DESCRIPTION
## ✨ What does your extension provide?
The Wikipedia extension now splits the bounding box when it is too big. The area will also be split when there where to many geosearch results for an area and it is possible that some results may have been ignored  

## 🧪 Testing
Tested using the ExtensionTester project

## ✔ Prove to us that your extension works.
Extension does not work for the osta app yet as it requires the math function to be accessible to the JSPython interpreter

## 📃 Checklist
1) Fill in all necessary fields:
- [X] Make sure you’ve provided information for essential fields such as the extension’s name, description, and type.
- [X] Double-check that you haven’t missed any required properties.
    
2) Verify property details:
- [X] Ensure that the information you’ve entered for each property aligns with the extension’s purpose and functionality.
- [X] Review the properties thoroughly to avoid any discrepancies.
    
3) Version details:
- [X] Fill in the version field with all the necessary details.
- [X] Include relevant information about the extension’s version, such as changes, improvements, or bug fixes.
    
4) Safety and documentation:
- [X] While confidence is great, consider reviewing the documentation one more time to ensure your extension is safe to use.
- [X] Confirm that you’ve followed best practices and guidelines.
